### PR TITLE
Ignore connection errors

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
@@ -237,7 +237,9 @@ public final class RealSubscriptionManager implements SubscriptionManager {
     } else if (message instanceof OperationServerMessage.Complete) {
       onCompleteServerMessage((OperationServerMessage.Complete) message);
     } else if (message instanceof OperationServerMessage.ConnectionError) {
-      disconnect(true);
+      // Jordan - Ignore connection errors, as they don't always mean the socket should be disconnected
+      // See https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_error
+//      disconnect(true);
     } else if (message instanceof OperationServerMessage.ConnectionKeepAlive) {
       resetConnectionKeepAliveTimerTask();
     }


### PR DESCRIPTION
There are times we receive a connection_error, but the docs say that there are times where we just want to ignore the message rather than disconnect the socket: https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_error

This should ignore the connection_error messages and we leave it up to the server to close the socket connection if it's for an unauthorized connection