### PR TITLE
Consider newlines when generating operation ids

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
@@ -55,7 +55,7 @@ class OperationTypeSpecBuilder(
   private fun TypeSpec.Builder.addOperationId(operation: Operation): TypeSpec.Builder {
     addField(FieldSpec.builder(ClassNames.STRING, OPERATION_ID_FIELD_NAME)
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-        .initializer("\$S", operation.sourceWithFragments?.filter { it != '\n' }?.sha256())
+        .initializer("\$S", operation.sourceWithFragments?.sha256())
         .build()
     )
 


### PR DESCRIPTION
The operation IDs in the API.json files generated by apollo were different from the operation IDs used in the app.  This should align the two.